### PR TITLE
DEPLOY-267 Investigate why SSO chart with latest tag image doesn't work

### DIFF
--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -26,8 +26,6 @@ alfresco-activiti-cloud-gateway:
   rabbitmqReleaseName: "jaunty-walrus-rabbitmq"
 alfresco-activiti-cloud-sso-idm:
   enabled: true
-  image:
-    tag: 7-201710-EA
 
 alfresco-content-services:
   enabled: true


### PR DESCRIPTION
Removed rewrite of the image tag for alfresco-activiti-cloud-sso-idm to use the default latest tag from the SSO chart.