### PR TITLE
DEPLOY-462: Bamboo: test_dbp_setup.sh failing due to incorrect number of pods

### DIFF
--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -15,6 +15,7 @@ alfresco-process-services:
 
 alfresco-content-services:
   enabled: true
+  registryPullSecrets: quay-registry-secret
   alfresco-infrastructure:
     enabled: false
   repository:


### PR DESCRIPTION
Fix registry secret option for acs