### PR TITLE
AUTH-124: DBP chart pulls in the APS chart with SSO Enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ helm install alfresco-incubator/alfresco-dbp \
 --set alfresco-content-services.share.resources.requests.memory="1000Mi" \
 --set alfresco-content-services.postgresql.resources.requests.memory="500Mi" \
 --set alfresco-process-services.processEngine.environment.IDENTITY_SERVICE_AUTH="http://localhost-k8s/auth" \
---set alfresco-process-services.processEngine.environment.IDENTITY_SERVICE_ENABLED=true \
 --set alfresco-process-services.processEngine.resources.requests.memory="1000Mi" \
 --set alfresco-process-services.adminApp.resources.requests.memory="250Mi"
 ```

--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -12,6 +12,19 @@ alfresco-process-services:
       memory: "2000Mi"
     limits:
       memory: "3000Mi"
+  envVar:
+    IdentityServiceEnabled: false
+    KeycloakEnabled: false
+    IdentityServiceURL: "<ingresscontrollerurl>/auth/"
+    IdentityServiceRealm: "alfresco"
+    IdentityServiceSSLRequired: none
+    IdentityServiceResource: "alfresco"
+    IdentityServicePrincipalAttribute: "email"
+    IdentityServiceCredentialsSecret: 287c9941-3b79-4f69-9896-35ec3d1d9e6f
+    IdentityServiceRefreshToken: true
+    IdentityServiceAutodetectBearerOnly: true
+    IdentityServiceTokenStore: "cookie"
+    IdentityServiceEnableBasicAuth: true
 
 alfresco-content-services:
   enabled: true

--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -16,19 +16,6 @@ alfresco-process-services:
       memory: "2000Mi"
     limits:
       memory: "3000Mi"
-  envVar:
-    IdentityServiceEnabled: false
-    KeycloakEnabled: false
-    IdentityServiceURL: "<ingresscontrollerurl>/auth/"
-    IdentityServiceRealm: "alfresco"
-    IdentityServiceSSLRequired: none
-    IdentityServiceResource: "alfresco"
-    IdentityServicePrincipalAttribute: "email"
-    IdentityServiceCredentialsSecret: 287c9941-3b79-4f69-9896-35ec3d1d9e6f
-    IdentityServiceRefreshToken: true
-    IdentityServiceAutodetectBearerOnly: true
-    IdentityServiceTokenStore: "cookie"
-    IdentityServiceEnableBasicAuth: true
 
 alfresco-content-services:
   enabled: true


### PR DESCRIPTION
Update helm install dbp command since the Identity Service is enabled at APS level by default in the DBP Chart.