### PR TITLE
DEPLOY-565: Add notes for Kubernetes Dashboard (with Docker Desktop for Mac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,3 +340,31 @@ You may also need to remove this namespace when you no longer need it.
 ```bash
 kubectl delete namespace $DESIREDNAMESPACE
 ```
+
+#### Install the Kubernetes Dashboard.
+
+To install the [Dashboard](https://github.com/kubernetes/dashboard/blob/master/README.md) you can either use the recommended approach (which is more secure) ...
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
+```
+
+To access the dashboard view [these instructions](https://github.com/kubernetes/dashboard/wiki/Accessing-Dashboard---1.7.X-and-above).
+
+... or you can use the alternative approach (which makes access easier in a local development environment)
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/alternative/kubernetes-dashboard.yaml
+```
+
+To access the dashboard, you can start local proxy server.
+
+```bash
+$ kubectl proxy
+```
+
+Once proxy server is started you should be able to access Dashboard from your browser at:
+
+http://localhost:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/
+
+For more details view [these instructions](https://github.com/kubernetes/dashboard/wiki/Accessing-Dashboard---1.6.X-and-below).


### PR DESCRIPTION
- note: adapted from https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/running-a-cluster.md