### PR TITLE
[DEPLOY-614] Add Quay.io secret setup information to Desktop setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,13 @@ sudo sh -c 'echo "`ipconfig getifaddr en0`       localhost-k8s" >> /etc/hosts'; 
 
 *Note:* If your IP address changes you will need to update the `/etc/hosts` entry for localhost-k8s.
 
-### 9. Deploy the DBP
+### 9. Docker Registry Pull Secrets
+
+See the Anaxes Shipyard documentation on [secrets](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md).
+
+*Note*: You can reuse the secrets.yaml file from charts/incubator directory.  
+
+### 10. Deploy the DBP
 
 The extended install command configures the hostnames, URLs and memory requirements needed to run in Docker for Desktop.  It also configures the time for initiating the kubernetes probes to test if a service is available.
 
@@ -289,7 +295,7 @@ helm install alfresco-incubator/alfresco-dbp \
 --set alfresco-process-services.adminApp.resources.requests.memory="250Mi"
 ```
 
-### 10. Check Deployment Status of DBP
+### 11. Check Deployment Status of DBP
 
 ```bash
 kubectl get pods
@@ -297,7 +303,7 @@ kubectl get pods
 
 *Note:* When checking status, your pods should be `READY 1/1` and `STATUS Running`
 
-### 11. Check DBP Components
+### 12. Check DBP Components
 
 You can access DBP components at the following URLs:
 - http://localhost-k8s/alfresco
@@ -319,7 +325,7 @@ You can access DBP components at the following URLs:
 - The http://localhost-k8s/activiti-admin/solr endpoint is disabled by default.   
   - See https://github.com/Alfresco/acs-deployment/blob/master/docs/examples/search-external-access.md for more information.
 
-### 12. Teardown:
+### 13. Teardown:
 
 ```bash
 helm ls


### PR DESCRIPTION
- Add new step for including quay secret to docker desktop setup.