### PR TITLE
DEPLOY-563: Stable Infrastructure Chart for ACS 6.1 (with ActiveMQ)

### DIFF
--- a/charts/incubator/alfresco-dbp/requirements.yaml
+++ b/charts/incubator/alfresco-dbp/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     condition: alfresco-content-application.enabled
     repository: https://kubernetes-charts.alfresco.com/incubator
   - name: alfresco-content-services
-    version: 1.1.4
+    version: 1.1.5
     condition: alfresco-content-services.enabled
     repository: https://kubernetes-charts.alfresco.com/incubator
   - name: alfresco-sync-service
@@ -16,6 +16,6 @@ dependencies:
     condition: alfresco-sync-service.enabled
     repository: https://kubernetes-charts.alfresco.com/incubator
   - name: alfresco-infrastructure
-    version: 2.0.5-SNAPSHOT
+    version: 3.0.0-SNAPSHOT
     condition: alfresco-infrastructure.enabled
     repository: https://kubernetes-charts.alfresco.com/incubator

--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -20,12 +20,14 @@ alfresco-process-services:
 alfresco-content-services:
   enabled: true
   registryPullSecrets: quay-registry-secret
+  messageBroker:
+    url:
+    user: admin
+    password: admin
   alfresco-infrastructure:
     enabled: false
     activemq:
-      adminUser: 
-        username: admin
-        password: admin
+      enabled: false
   repository:
 # DEPLOY-466 / DEPLOY-467 - Remove image pin as we are using the ACS provided images
 #    image:

--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -22,17 +22,16 @@ alfresco-content-services:
   registryPullSecrets: quay-registry-secret
   alfresco-infrastructure:
     enabled: false
+    activemq:
+      adminUser: 
+        username: admin
+        password: admin
   repository:
 # DEPLOY-466 / DEPLOY-467 - Remove image pin as we are using the ACS provided images
 #    image:
 #      repository: quay.io/alfresco/alfresco-dbp-repository
 #      tag: "0.3-SNAPSHOT"
     environment:
-      # The ACTIVEMQ_HOST is the DNS name of the ActiveMQ Broker. If deployed 
-      # from the Alfresco ActiveMQ Chart it will be
-      # <Infrastructure Release Name>-activemq-broker
-      ACTIVEMQ_HOST: "<infrastructure-releasename>-activemq-broker"
-      # FIXME: Port 61616 is hard-coded here, but is configurable elsewhere
       # The SYNC_SERVICE_URI should contain the details of the ingress host and port.
       SYNC_SERVICE_URI: "<ingresscontrollerurl>/syncservice"
       # The IDENTITY_SERVICE_URI should contain the details of the ingress host and port.
@@ -44,7 +43,6 @@ alfresco-content-services:
         -Ddeployment.method=HELM_CHART
         -Xms2000M -Xmx2000M
         -Ddsync.service.uris=\"$SYNC_SERVICE_URI\"
-        -Dmessaging.broker.url=\"failover:(tcp://${ACTIVEMQ_HOST}:61616)?timeout=3000\"
         -Dauthentication.chain=identity-service1:identity-service,alfrescoNtlm1:alfrescoNtlm
         -Didentity-service.enable-basic-auth=true
         -Didentity-service.authentication.validation.failure.silent=false
@@ -56,6 +54,7 @@ alfresco-content-services:
 #    image:
 #      repository: quay.io/alfresco/alfresco-dbp-share
 #      tag: "0.3-SNAPSHOT"
+  
 alfresco-sync-service:
   enabled: false
   alfresco-infrastructure:
@@ -63,9 +62,5 @@ alfresco-sync-service:
 
 alfresco-infrastructure:
   enabled: true
-  #DEPLOY-613 - Multiple ActiveMQ instances are deployed
-  #TODO Remove as part of DEPLOY-563
   activemq:
-    enabled: false  
-
-  
+    enabled: true

--- a/charts/incubator/alfresco-dbp/values.yaml
+++ b/charts/incubator/alfresco-dbp/values.yaml
@@ -62,5 +62,3 @@ alfresco-sync-service:
 
 alfresco-infrastructure:
   enabled: true
-  activemq:
-    enabled: true


### PR DESCRIPTION
Update DBP chart to use the latest Alfresco Infrastructure and ACS Charts.
