### PR TITLE
MSP-199 & MSP-231: Update DBP templates to work with latest ACS templates

### DIFF
--- a/README-cfn.md
+++ b/README-cfn.md
@@ -10,7 +10,7 @@ This project contains the code for the AWS-based DBP product on AWS Cloud using 
 
 #### Limitations
 
-Within this project we rely on [ACS Deployment AWS](https://github.com/Alfresco/acs-deployment-aws) to set the EKS cluster trough a set of defined cloudformation templates. Infrastructure limitations are set by the before mentioned project.
+Within this project we rely on [ACS Deployment AWS](https://github.com/Alfresco/acs-deployment-aws) to set the EKS cluster through a set of defined cloudformation templates. Infrastructure limitations are set by the before mentioned project.
 
 ### Prerequisites
 * You need to create an IAM user that has the following [permissions](#Permissions) 
@@ -70,20 +70,28 @@ s3://<bucket_name> e.g. my-s3-bucket
           |-- <key_prefix> e.g. development
           |       |-- lambdas
           |       |      |-- eks-helper-lambda.zip
+          |       |      +-- cluster-init-helper-lambda.zip
           |       |      +-- alfresco-lambda-empty-s3-bucket.jar
           |       |      +-- helm-helper-lambda.zip
           |       |-- scripts
-          |       |      |-- deleteIngress.sh
+          |       |      |-- deleteAcs.sh
+          |       |      +-- deleteIngress.sh
           |       |      +-- getElb.sh
+          |       |      +-- hardening_bootstrap.sh
+          |       |      +-- helmAcs.sh
           |       |      +-- helmDeploy.sh
+          |       |      +-- helmFluentd.sh
           |       |      +-- helmIngress.sh
           |       |      +-- helmInit.sh
           |       |-- templates
-          |       |      |-- acs.yaml
-          |       |      +-- full-deployment.yaml
-          |       |      +-- full-master-parameters.json
+          |       |      |-- acs-deployment-master.yaml
+          |       |      +-- acs-master-parameters.json
+          |       |      +-- acs.yaml
           |       |      +-- bastion-and-eks-cluster.yaml
+          |       |      +-- dbp-install.yaml
           |       |      +-- efs.yaml
+          |       |      +-- full-deployment-parameters.json
+          |       |      +-- full-deployment.yaml
           |       |      +-- rds.yaml
           |       |      +-- s3-bucket.yaml
 ```

--- a/aws/templates/dbp-install.yaml
+++ b/aws/templates/dbp-install.yaml
@@ -35,8 +35,6 @@ Metadata:
             - RegistryCredentials
             - RepoPods
             - Route53DnsZone
-            - NodeInstanceRoleArn
-            - EC2LogGroup
 
       ParameterLabels:
         TemplateBucketName:
@@ -83,11 +81,7 @@ Metadata:
           default: The number of repository pods in the cluster
         Route53DnsZone:
           default: The hosted zone to create Route53 Record for the Alfresco Digital Business Platform
-        NodeInstanceRoleArn:
-          default: ARN for the worker nodes instance role (with logging policy)
-        EC2LogGroup:
-          default: Log group name to ship all ACS logs to with Fluentd
-          
+
 Parameters:
     TemplateBucketName:
       AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
@@ -163,70 +157,9 @@ Parameters:
     Route53DnsZone:
       Type: String
       Description: The hosted zone to create Route53 Record for DBP
-    NodeInstanceRoleArn:
-      Type: String
-      Description: ARN for the worker nodes instance role (with logging policy)
-    EC2LogGroup:
-      Type: String
-      Description: Log group name to ship all ACS logs to with Fluentd
 
 Resources:
   # SSM documents to run helm commands on the bastion
-  HelmDownloadScript:
-    Type: "AWS::SSM::Document"
-    Properties:
-      Content:
-        schemaVersion: "2.2"
-        description: Download helm init helper script
-        mainSteps:
-          - action: aws:downloadContent
-            name: downloadHelmScriptsDirectory
-            inputs:
-              sourceType: "S3"
-              sourceInfo: !Sub "{ \"path\": \"https://${TemplateBucketName}.s3.amazonaws.com/${TemplateBucketKeyPrefix}/scripts\" }"
-              destinationPath: "/tmp"
-      DocumentType: Command
-
-  HelmInitRunScript:
-    Type: "AWS::SSM::Document"
-    Properties:
-      Content:
-        schemaVersion: "2.2"
-        description: Execute helm init script to deploy tiller
-        mainSteps:
-          - action: aws:runShellScript
-            name: helmInit
-            inputs:
-              workingDirectory: "/root"
-              runCommand: 
-                - "chmod u+x /tmp/helmInit.sh"
-                - "/tmp/helmInit.sh"
-              timeoutSeconds: 60
-      DocumentType: Command
-
-  HelmInstallFluentdRunScript:
-    Type: "AWS::SSM::Document"
-    Properties:
-      Content:
-        schemaVersion: "2.2"
-        description: Install Fluentd K8s CloudWatchLogs Helm chart
-        mainSteps:
-          - action: aws:runShellScript
-            name: helmInstallFluentd
-            inputs:
-              workingDirectory: "/root"
-              runCommand:
-                - "chmod u+x /tmp/helmFluentd.sh"
-                - !Sub "/tmp/helmFluentd.sh\
-                  \ --stackname alfresco\
-                  \ --namespace ${K8sNamespace}\
-                  \ --instance-role ${NodeInstanceRoleArn}\
-                  \ --region ${AWS::Region}\
-                  \ --loggroup ${EC2LogGroup}\
-                  \ --install"
-              timeoutSeconds: 60
-      DocumentType: Command
-
   HelmInstallIngressRunScript:
     Type: "AWS::SSM::Document"
     Properties:
@@ -247,7 +180,7 @@ Resources:
                   \ --aws-cert-arn ${ElbCertArn}\
                   \ --aws-cert-policy ${ElbCertPolicy}\
                   \ --external-name ${ExternalName}"
-              timeoutSeconds: 300
+              timeoutSeconds: 60
       DocumentType: Command
       
   HelmInstallRunScript:
@@ -278,7 +211,7 @@ Resources:
                   \ --repo-pods ${RepoPods}\
                   \ --chart-version 0.8.1\
                   \ --install"
-              timeoutSeconds: 60
+              timeoutSeconds: 90
       DocumentType: Command
 
   HelmUpgradeRunScript:
@@ -314,7 +247,24 @@ Resources:
                 - !Sub "/tmp/getElb.sh --ingress-release ${IngressReleaseName} --namespace ${K8sNamespace}"
               timeoutSeconds: 60
       DocumentType: Command
-  
+
+  HelmDeleteAcsRunScript:
+    Type: "AWS::SSM::Document"
+    Properties:
+      Content:
+        schemaVersion: "2.2"
+        description: Delete ACS Helm Chart
+        mainSteps:
+          - action: aws:runShellScript
+            name: helmDeleteAcs
+            inputs:
+              workingDirectory: "/root"
+              runCommand:
+                - "chmod u+x /tmp/deleteAcs.sh"
+                - !Sub "/tmp/deleteAcs.sh --acs-release ${ReleaseName}"
+              timeoutSeconds: 120
+      DocumentType: Command
+
   HelmDeleteIngressRunScript:
     Type: "AWS::SSM::Document"
     Properties:
@@ -400,7 +350,7 @@ Resources:
       Handler: helmHelperLambda.handler
       Role: !GetAtt HelmHelperLambdaRole.Arn
       Runtime: python2.7
-      Timeout: 360
+      Timeout: 420
       Description: "A custom resource to manage Helm charts used for deploying Alfresco Applications"
 
   HelmHelperLambdaCustomResource:
@@ -411,14 +361,12 @@ Resources:
       VPCID: !Ref VPCID
       NodeSecurityGroup: !Ref NodeSecurityGroup
       BastionAutoScalingGroup: !Ref BastionAutoScalingGroup
-      HelmDownloadScript: !Ref HelmDownloadScript
-      HelmInitRunScript: !Ref HelmInitRunScript
       HelmInstallIngressRunScript: !Ref HelmInstallIngressRunScript
       HelmInstallRunScript: !Ref HelmInstallRunScript
       HelmUpgradeRunScript: !Ref HelmUpgradeRunScript
       GetElbEndpointRunScript: !Ref GetElbEndpointRunScript
+      HelmDeleteAcsRunScript: !Ref HelmDeleteAcsRunScript
       HelmDeleteIngressRunScript: !Ref HelmDeleteIngressRunScript
-      HelmInstallFluentdRunScript: !Ref HelmInstallFluentdRunScript
 
   Route53DnsRecord:
     Type: AWS::Route53::RecordSetGroup

--- a/aws/templates/dbp-install.yaml
+++ b/aws/templates/dbp-install.yaml
@@ -33,7 +33,10 @@ Metadata:
             - RDSEndpoint
             - DatabasePassword
             - RegistryCredentials
+            - RepoPods
             - Route53DnsZone
+            - NodeInstanceRoleArn
+            - EC2LogGroup
 
       ParameterLabels:
         TemplateBucketName:
@@ -75,9 +78,15 @@ Metadata:
         IngressReleaseName:
           default: The helm chart release name of nginx-ingress
         ReleaseName:
-          default: The helm chart release name of the Alfresco Digital Business Platform 
+          default: The helm chart release name of the Alfresco Digital Business Platform
+        RepoPods:
+          default: The number of repository pods in the cluster
         Route53DnsZone:
-          default: The hosted zone to create Route53 Record for the Alfresco Digital Business Platform 
+          default: The hosted zone to create Route53 Record for the Alfresco Digital Business Platform
+        NodeInstanceRoleArn:
+          default: ARN for the worker nodes instance role (with logging policy)
+        EC2LogGroup:
+          default: Log group name to ship all ACS logs to with Fluentd
           
 Parameters:
     TemplateBucketName:
@@ -138,21 +147,28 @@ Parameters:
       NoEcho: True
     RegistryCredentials:
       Type: String
-      Description: The private registry credentials base64
+      Description: The private registry credentials in base64 format
       NoEcho: True
-      Default: false
+      Default: ""
     IngressReleaseName:
       Type: String
       Description: The helm chart release name of nginx-ingress
     ReleaseName:
       Type: String
-      Description: The helm chart release name of the Alfresco Digital Business Platform 
+      Description: The helm chart release name of the Alfresco Digital Business Platform
+    RepoPods:
+      Type: String
+      Description: The number of repository pods in the cluster
+      Default: "2"
     Route53DnsZone:
       Type: String
       Description: The hosted zone to create Route53 Record for DBP
-
-Conditions:
-  PrivateRegistry: !Not [!Equals [!Ref RegistryCredentials, false]]
+    NodeInstanceRoleArn:
+      Type: String
+      Description: ARN for the worker nodes instance role (with logging policy)
+    EC2LogGroup:
+      Type: String
+      Description: Log group name to ship all ACS logs to with Fluentd
 
 Resources:
   # SSM documents to run helm commands on the bastion
@@ -188,6 +204,29 @@ Resources:
               timeoutSeconds: 60
       DocumentType: Command
 
+  HelmInstallFluentdRunScript:
+    Type: "AWS::SSM::Document"
+    Properties:
+      Content:
+        schemaVersion: "2.2"
+        description: Install Fluentd K8s CloudWatchLogs Helm chart
+        mainSteps:
+          - action: aws:runShellScript
+            name: helmInstallFluentd
+            inputs:
+              workingDirectory: "/root"
+              runCommand:
+                - "chmod u+x /tmp/helmFluentd.sh"
+                - !Sub "/tmp/helmFluentd.sh\
+                  \ --stackname alfresco\
+                  \ --namespace ${K8sNamespace}\
+                  \ --instance-role ${NodeInstanceRoleArn}\
+                  \ --region ${AWS::Region}\
+                  \ --loggroup ${EC2LogGroup}\
+                  \ --install"
+              timeoutSeconds: 60
+      DocumentType: Command
+
   HelmInstallIngressRunScript:
     Type: "AWS::SSM::Document"
     Properties:
@@ -208,7 +247,7 @@ Resources:
                   \ --aws-cert-arn ${ElbCertArn}\
                   \ --aws-cert-policy ${ElbCertPolicy}\
                   \ --external-name ${ExternalName}"
-              timeoutSeconds: 60
+              timeoutSeconds: 300
       DocumentType: Command
       
   HelmInstallRunScript:
@@ -236,6 +275,7 @@ Resources:
                   \ --s3bucket-name ${S3BucketName}\
                   \ --s3bucket-location ${AWS::Region}\
                   \ --s3bucket-alias ${S3BucketKMSAlias}\
+                  \ --repo-pods ${RepoPods}\
                   \ --chart-version 0.8.1\
                   \ --install"
               timeoutSeconds: 60
@@ -360,7 +400,7 @@ Resources:
       Handler: helmHelperLambda.handler
       Role: !GetAtt HelmHelperLambdaRole.Arn
       Runtime: python2.7
-      Timeout: 120
+      Timeout: 360
       Description: "A custom resource to manage Helm charts used for deploying Alfresco Applications"
 
   HelmHelperLambdaCustomResource:
@@ -378,11 +418,10 @@ Resources:
       HelmUpgradeRunScript: !Ref HelmUpgradeRunScript
       GetElbEndpointRunScript: !Ref GetElbEndpointRunScript
       HelmDeleteIngressRunScript: !Ref HelmDeleteIngressRunScript
+      HelmInstallFluentdRunScript: !Ref HelmInstallFluentdRunScript
 
   Route53DnsRecord:
     Type: AWS::Route53::RecordSetGroup
-    DependsOn:
-      - HelmHelperLambdaCustomResource
     Properties:
       Comment: DNS Record for ELB
       HostedZoneName: !Ref Route53DnsZone

--- a/aws/templates/full-deployment.yaml
+++ b/aws/templates/full-deployment.yaml
@@ -32,6 +32,8 @@ Metadata:
           - NodesMetricsEnabled
           - K8sNamespace
           - DeployInfrastructureOnly
+          - IndexEBSVolumeSize
+          - IndexEBSIops
       - Label:
           default: S3 Cross Replication Bucket for storing ACS content store
         Parameters:
@@ -63,6 +65,7 @@ Metadata:
           - AlfrescoPassword
           - RegistryCredentials
           - Route53DnsZone
+          - RepoPods
 
     ParameterLabels:
       AvailabilityZones:
@@ -145,8 +148,14 @@ Metadata:
         default: Destination Replication Bucket
       ReplicationBucketKMSEncryptionKey:
         default: Destination Bucket KMS Encryption Key
+      RepoPods:
+        default: The number of repository pods in the cluster
       DeployInfrastructureOnly:
         default: Deploys only eks cluster and worker nodes
+      IndexEBSVolumeSize:
+        default: Size in GB for the Index EBS volume
+      IndexEBSIops:
+        default: IOPS for the Index EBS volume (300 to 20000)
 
 Parameters:
   AvailabilityZones:
@@ -230,7 +239,7 @@ Parameters:
   RDSCreateSnapshotWhenDeleted:
     Description: Creates a snapshot when the stack gets deleted
     Type: String
-    Default: true
+    Default: "true"
     AllowedValues:
     - "true"
     - "false"
@@ -248,17 +257,17 @@ Parameters:
     Type: String
     MinLength: 1
     Description: "The desired number of Bastion instance to run"
-    Default: 1
+    Default: "1"
   MaxNumberOfBastionNodes:
     Type: String
     MinLength: 1
     Description: "The maximum number of Bastion instances to run"
-    Default: 1
+    Default: "1"
   MinNumberOfBastionNodes:
     Type: String
     MinLength: 1
     Description: "The minimum number of Bastion instances to run"
-    Default: 1
+    Default: "1"
   NodeInstanceType:
     Type: "String"
     Default: "m4.xlarge"
@@ -278,21 +287,21 @@ Parameters:
     Type: String
     MinLength: 1
     Description: "The desired number of EKS Worker Nodes to run"
-    Default: 2
+    Default: "2"
   MaxNumberOfNodes:
     Type: String
     MinLength: 1
     Description: "The maximum number of EKS Worker Nodes to run"
-    Default: 3
+    Default: "3"
   MinNumberOfNodes:
     Type: String
     MinLength: 1
     Description: "The minimum number of EKS Worker Nodes to run"
-    Default: 2
+    Default: "2"
   NodesMetricsEnabled:
     Description: Enables all CloudWatch metrics for the nodes auto scaling group
     Type: String
-    Default: false
+    Default: "false"
     AllowedValues:
     - "true"
     - "false"
@@ -383,7 +392,7 @@ Parameters:
   UseCrossRegionReplication:
     Description: "Set to true if you want to add an S3 Bucket for replication"
     Type: String
-    Default: false
+    Default: "false"
     AllowedValues: 
       - "true"
       - "false"
@@ -399,16 +408,27 @@ Parameters:
     Description: "The KMS encryption key for the destination bucket"
     Type: "String"
     Default: ""
+  RepoPods:
+    Type: String
+    Description: The number of repository pods in the cluster
+    Default: "2"
   DeployInfrastructureOnly:
     Description: "Set to true if you only want the eks cluster deployed"
     Type: String
-    Default: false
+    Default: "false"
     AllowedValues: 
       - "true"
       - "false"
+  IndexEBSVolumeSize:
+    Type: String
+    Description: Size in GB for the Index EBS volume
+    Default: "100"
+  IndexEBSIops:
+    Type: String
+    Description: IOPS for the Index EBS volume (300 to 20000)
+    Default: "300"
 
 Conditions:
-  isUseCrossRegionReplication: !Equals [!Ref UseCrossRegionReplication, "true"]
   isDeployInfrastructureOnly: !Equals [!Ref DeployInfrastructureOnly, "true"]
   deployDbp: !Not [Condition: isDeployInfrastructureOnly]
 
@@ -431,7 +451,7 @@ Resources:
         PrivateSubnet2ACIDR: !Ref PrivateSubnet2CIDR
         PublicSubnet1CIDR: !Ref PublicSubnet1CIDR
         PublicSubnet2CIDR: !Ref PublicSubnet2CIDR
-        CreatePrivateSubnets: true
+        CreatePrivateSubnets: "true"
         VPCCIDR: !Ref VPCCIDR
 
   EC2LogGroup:
@@ -463,6 +483,15 @@ Resources:
                   - logs:PutMetricFilter
                   - logs:CreateLogGroup
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${EC2LogGroup}:*"
+                Effect: Allow
+        - PolicyName: ebs-volume-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - ec2:AttachVolume
+                  - ec2:DetachVolume
+                Resource: !Sub "arn:aws:ec2:*:*:volume/*"
                 Effect: Allow
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -497,9 +526,6 @@ Resources:
 
   EFSStack:
     Type: AWS::CloudFormation::Stack
-    DependsOn:
-      - VPCStack
-      - NodeSecurityGroup
     Properties:
       Tags:
         - Key: Name
@@ -514,11 +540,10 @@ Resources:
         PrivateSubnet2ID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         SecurityGroup: !Ref NodeSecurityGroup
 
-  BastionAndEksClusterStack:
+  EKSStack:
     Type: AWS::CloudFormation::Stack
     DependsOn:
-      - VPCStack
-      - NodeInstanceRole
+      - SolrVolume1
     Properties:
       Tags:
         - Key: Name
@@ -555,13 +580,10 @@ Resources:
         DesiredNumberOfNodes: !Ref DesiredNumberOfNodes
         NodesMetricsEnabled: !Ref NodesMetricsEnabled
         EksExternalUserArn: !Ref EksExternalUserArn
-        K8sNamespace: !Ref K8sNamespace
 
   RDSStack:
     Type: AWS::CloudFormation::Stack
     Condition: deployDbp
-    DependsOn:
-      - VPCStack
     Properties:
       Tags:
         - Key: Name
@@ -576,14 +598,16 @@ Resources:
         PrivateSubnet2: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         NodeSecurityGroup: !Ref NodeSecurityGroup
         VPCID: !GetAtt VPCStack.Outputs.VPCID
+        RDSInstanceType: !Ref RDSInstanceType
+        RDSAllocatedStorage: !Ref RDSAllocatedStorage
+        RDSDBName: !Ref RDSDBName
+        RDSUsername: !Ref RDSUsername
         RDSPassword: !Ref RDSPassword
         RDSCreateSnapshotWhenDeleted: !Ref RDSCreateSnapshotWhenDeleted
 
   S3Stack:
     Type: AWS::CloudFormation::Stack
     Condition: deployDbp
-    DependsOn:
-      - NodeInstanceRole
     Properties:
       Tags:
         - Key: Name
@@ -606,11 +630,6 @@ Resources:
   DBPStack:
     Type: AWS::CloudFormation::Stack
     Condition: deployDbp
-    DependsOn:
-      - EFSStack
-      - BastionAndEksClusterStack
-      - RDSStack
-      - S3Stack
     Properties:
       Tags:
         - Key: Name
@@ -626,8 +645,8 @@ Resources:
         EFSName: !GetAtt EFSStack.Outputs.EFSName
         S3BucketName: !GetAtt S3Stack.Outputs.S3BucketName
         S3BucketKMSAlias: !GetAtt S3Stack.Outputs.S3BucketKMSAlias
-        EKSName: !GetAtt BastionAndEksClusterStack.Outputs.EksClusterName
-        BastionAutoScalingGroup: !GetAtt BastionAndEksClusterStack.Outputs.BastionAutoScalingGroup
+        EKSName: !GetAtt EKSStack.Outputs.EksClusterName
+        BastionAutoScalingGroup: !GetAtt EKSStack.Outputs.BastionAutoScalingGroup
         VPCID: !GetAtt VPCStack.Outputs.VPCID
         NodeSecurityGroup: !Ref NodeSecurityGroup
         K8sNamespace: !Ref K8sNamespace
@@ -641,7 +660,23 @@ Resources:
         RegistryCredentials: !Ref RegistryCredentials
         IngressReleaseName: !Ref IngressReleaseName
         ReleaseName: !Ref ReleaseName
+        RepoPods: !Ref RepoPods
         Route53DnsZone: !Ref Route53DnsZone
+        NodeInstanceRoleArn: !GetAtt NodeInstanceRole.Arn
+        EC2LogGroup: !Ref EC2LogGroup
+
+  SolrVolume1:
+    Type: AWS::EC2::Volume
+    Properties:
+      AutoEnableIO: false
+      AvailabilityZone: !Select [ 0, !Ref AvailabilityZones ]
+      Encrypted: false
+      Iops: !Ref IndexEBSIops
+      Size: !Ref IndexEBSVolumeSize
+      VolumeType: io1
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-eks-SolrVolume1"
 
 Outputs:
   # VPC stack
@@ -652,33 +687,33 @@ Outputs:
 
   # Bastion stack
   BastionSubstackName:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.SubstackName
+    Value: !GetAtt EKSStack.Outputs.SubstackName
   BastionSecurityGroup:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionSecurityGroup
+    Value: !GetAtt EKSStack.Outputs.BastionSecurityGroup
   BastionLaunchConfiguration:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionLaunchConfiguration
+    Value: !GetAtt EKSStack.Outputs.BastionLaunchConfiguration
   BastionAutoScalingGroup:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionAutoScalingGroup
+    Value: !GetAtt EKSStack.Outputs.BastionAutoScalingGroup
   BastionEIP:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionEIP
+    Value: !GetAtt EKSStack.Outputs.BastionEIP
   BastionInstanceProfile:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionInstanceProfile
+    Value: !GetAtt EKSStack.Outputs.BastionInstanceProfile
   BastionInstanceRole:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionInstanceRole
+    Value: !GetAtt EKSStack.Outputs.BastionInstanceRole
   EC2LogGroup:
     Value: !Ref EC2LogGroup
 
   # EKS Cluster
   ControlPlaneSecurityGroup:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.ControlPlaneSecurityGroup
+    Value: !GetAtt EKSStack.Outputs.ControlPlaneSecurityGroup
   EksClusterName:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksClusterName
+    Value: !GetAtt EKSStack.Outputs.EksClusterName
   EksEndpoint:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksEndpoint
+    Value: !GetAtt EKSStack.Outputs.EksEndpoint
   EksCertAuthority:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksCertAuthority
+    Value: !GetAtt EKSStack.Outputs.EksCertAuthority
   EksServiceRoleArn:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksServiceRoleArn
+    Value: !GetAtt EKSStack.Outputs.EksServiceRoleArn
   NodeInstanceRoleArn:
     Value: !GetAtt NodeInstanceRole.Arn
   NodeSecurityGroupId:
@@ -711,7 +746,6 @@ Outputs:
   S3ReplicationBucket:
     Condition: deployDbp
     Value: !Ref ReplicationBucket
-    Condition: isUseCrossRegionReplication
 
   # RDS Stack
   RDSSubstackName:

--- a/aws/templates/full-deployment.yaml
+++ b/aws/templates/full-deployment.yaml
@@ -365,7 +365,7 @@ Parameters:
     ConstraintDescription: The helm chart release name of nginx-ingress can not be empty
     Type: String
     Description: The helm chart release name of nginx-ingress
-    Default: "alfresco"
+    Default: "alfresco-ingress"
   ReleaseName:
     AllowedPattern: ".+"
     ConstraintDescription: The helm chart release name of the Alfresco Digital Business Platform can not be empty
@@ -662,8 +662,6 @@ Resources:
         ReleaseName: !Ref ReleaseName
         RepoPods: !Ref RepoPods
         Route53DnsZone: !Ref Route53DnsZone
-        NodeInstanceRoleArn: !GetAtt NodeInstanceRole.Arn
-        EC2LogGroup: !Ref EC2LogGroup
 
   SolrVolume1:
     Type: AWS::EC2::Volume

--- a/aws/templates/full-deployment.yaml
+++ b/aws/templates/full-deployment.yaml
@@ -491,7 +491,7 @@ Resources:
               - Action:
                   - ec2:AttachVolume
                   - ec2:DetachVolume
-                Resource: !Sub "arn:aws:ec2:*:*:volume/*"
+                Resource: "arn:aws:ec2:*:*:volume/*"
                 Effect: Allow
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/aws/uploadHelper.sh
+++ b/aws/uploadHelper.sh
@@ -26,6 +26,7 @@ else
   aws s3 cp ./scripts s3://$S3_BUCKET/$S3_KEY_PREFIX/scripts --recursive
   aws s3 cp ../../acs-deployment-aws/templates s3://$S3_BUCKET/$S3_KEY_PREFIX/templates --recursive
   aws s3 cp ../../acs-deployment-aws/scripts s3://$S3_BUCKET/$S3_KEY_PREFIX/scripts --recursive
+  aws s3 cp ../../acs-deployment-aws/lambdas/cluster-init-helper-lambda/cluster-init-helper-lambda.zip s3://$S3_BUCKET/$S3_KEY_PREFIX/lambdas/
   aws s3 cp ../../acs-deployment-aws/lambdas/eks-helper-lambda/eks-helper-lambda.zip s3://$S3_BUCKET/$S3_KEY_PREFIX/lambdas/
   aws s3 cp ../../acs-deployment-aws/lambdas/helm-helper-lambda/helm-helper-lambda.zip s3://$S3_BUCKET/$S3_KEY_PREFIX/lambdas/
   aws s3 cp ../../acs-deployment-aws/lambdas/empty-s3-bucket/alfresco-lambda-empty-s3-bucket.jar s3://$S3_BUCKET/$S3_KEY_PREFIX/lambdas/


### PR DESCRIPTION
- Updated templates to support recent SOLR changes (DEPLOY-643)
- Fixed fall out from recent changes to ACS CloudFormation templates
- Added new cluster init lambda to uploadHelper script
- Removed resources no longer required by helm helper custom resource
- Added SSM document to delete the helm release
- Changed the default name of the ingress release as it was clashing with alfresco-fluentd release from ACS charts
- Changed the EKS/bastion stack name to be consistent with others
- Fixed various validation errors identified by cfn-python-lint
- Updated README