### PR TITLE
Need an empty prefix for the sed command to work on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Pull the minimal values file from the current repo:
 
 ```bash
 curl -O https://raw.githubusercontent.com/Alfresco/alfresco-dbp-deployment/master/charts/incubator/alfresco-dbp/minimal-values.yaml
-sed -i s/REPLACEME/$LOCALIP/g minimal-values.yaml
+sed -i "" s/REPLACEME/$LOCALIP/g minimal-values.yaml
 ```
 
 ### 11. Deploy the DBP


### PR DESCRIPTION
See https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux